### PR TITLE
Add GitHub Pages and Contributing Guide links to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Pablo
 
-Pablo is a color palette manager. You can use it to manage multiple palettes in one place, no matter what you're working on. With Pablo, you can optimize your workflow by having a view of all the colors your working with and easily copying them to your clipboard.
+[Pablo](https://ajsaraujo.github.io/pablo/index.html) is a color palette manager. You can use it to manage multiple palettes in one place, no matter what you're working on. With Pablo, you can optimize your workflow by having a view of all the colors your working with and easily copying them to your clipboard.
 
-![image-20210308195130210](docs/app-screenshot.png)
+Try out it online [here](https://ajsaraujo.github.io/pablo/index.html)!
+
+[![image-20210308195130210](docs/app-screenshot.png)](https://ajsaraujo.github.io/pablo/index.html)
 
 ## Installing and Running
 
@@ -28,11 +30,12 @@ Pablo will then be available at http://localhost:4200.
 
 Pablo is meant to be a simple project that anyone can contribute to and learn something by doing it. If you want to contribute to the project, just follow these steps:
 
-1. Comment on the issue you want to work on. If you have an idea that isn't on an issue yet, create the issue.
-2. Fork the repository.
-3. Clone your fork.
-4. Make your changes locally.
-5. Push them to your fork.
-6. Create a Pull Request from your fork to the repository's `develop` branch.
+1. Read the [first contributions guide](https://github.com/firstcontributions/first-contributions).
+2. Comment on the issue you want to work on. If you have an idea that isn't on an issue yet, create the issue.
+3. Fork the repository.
+4. Clone your fork.
+5. Make your changes locally.
+6. Push them to your fork.
+7. Create a Pull Request from your fork to the repository's `develop` branch.
 
 We'll then review it as soon as possible. If you're stuck with something, send an email to allanjuansil@gmail.com and we'll try our best. Keep in mind that refactorings are more than welcome!


### PR DESCRIPTION
Added GitHub Pages links,
- Links from the first instance of 'Pablo' of the main paragraph.
- Links from the image following the first paragraph.
- Added a second paragraph with a link indicating Pablo can be
  tested online.

Added Contribution Guide link as the first step in the
`Contributing` section of the `README.md`.

Closes #21